### PR TITLE
Updated the README.md to reflect the name of the extension in Brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## Brackets-wsSanitizer
+## White Space Sanitizer
 
 > Bring sanity to your code by keeping your indentation (spaces and tabs) consistent; the white space sanitizer.
 
-wsSanitizer goes really well with https://github.com/DennisKehrig/brackets-show-whitespace.
+White Space Sanitizer goes really well with https://github.com/DennisKehrig/brackets-show-whitespace.
 
 ## Features
 * Trims trailing white spaces
@@ -22,11 +22,11 @@ wsSanitizer goes really well with https://github.com/DennisKehrig/brackets-show-
 
 ## Brackets Preferences
 
-wsSanitizer leverages Brackets preferences, which means that you can specify per project settings by defining a `.brackets.json` in the root directory of your project. With Brackets preferences you can even define per file settings, which is really handy when dealing with third party libraries that may have different white space requirements than the rest of your project.
+White Space Sanitizer leverages Brackets preferences, which means that you can specify per project settings by defining a `.brackets.json` in the root directory of your project. With Brackets preferences you can even define per file settings, which is really handy when dealing with third party libraries that may have different white space requirements than the rest of your project.
 
-wsSanitizer also support per language settings, which enables you to enable/disabled sanitizing your documents using the Brackets language layer. For more information on the preferences system, you can read up on [this link](https://github.com/adobe/brackets/wiki/How-to-Use-Brackets#preferences).
+White Space Sanitizer also support per language settings, which enables you to enable/disabled sanitizing your documents using the Brackets language layer. For more information on the preferences system, you can read up on [this link](https://github.com/adobe/brackets/wiki/How-to-Use-Brackets#preferences).
 
-The sample `.brackets.json` below enables wsSanitizer for every file, with indentation of 2 white spaces. The configuration file also defines a `path` that disables wsSanitizer for `sanitize.js`, uses tabs, and each tab is 4 spaces.  Furthermore, you will be asked if you want to sanitize your documents when you open them.
+The sample `.brackets.json` below enables White Space Sanitizer for every file, with indentation of 2 white spaces. The configuration file also defines a `path` that disables White Space Sanitizer for `sanitize.js`, uses tabs, and each tab is 4 spaces.  Furthermore, you will be asked if you want to sanitize your documents when you open them.
 
 > Brackets `per file settings` cannot be configured as a user preference (globally); they can only be configured at the project level (project preference). Please read [this issue](https://github.com/MiguelCastillo/Brackets-wsSanitizer/issues/10) for details.
 


### PR DESCRIPTION
If you search in Brackets for "Brackets-wsSanitizer" you will not get any results...

The name of the Brackets extension is "White Space Sanitizer"

If you are inexperienced Brackets user that might, confused you and make finding the extension impossible.